### PR TITLE
Feat/32 종합 항목 추가

### DIFF
--- a/frontend/src/features/financial/components/ChangeRate.tsx
+++ b/frontend/src/features/financial/components/ChangeRate.tsx
@@ -1,15 +1,14 @@
 import BottomFixedContainer from '@/shared/ui/bottom-fixed/BottomFixedContainer';
-import InputLabel from '@/shared/ui/InputLabel';
 import { PageTitle } from '@/shared/ui/PageTitle';
 import ProgressButton from '@/shared/ui/ProgressButton';
 import {
   FinancialButtonWrapper,
   FinancialForm,
-  FinancialFormItem,
-  FinancialInput,
+  FinancialFormRow,
   FinancialSection,
 } from '../ui/Financial';
 import { useForm } from 'react-hook-form';
+import FinancialInputField from '../ui/FinancialInputField';
 
 type FormInput = Record<
   'salaryGrowthRate' | 'inflationRate' | 'investmentGrowthRate',
@@ -55,34 +54,28 @@ export function ChangeRate({
       </header>
 
       <FinancialForm onSubmit={handleSubmit(updateFinancialFormState)}>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="salaryGrowthRate">연봉 상승률</InputLabel>
-            <FinancialInput
-              type="number"
-              id="salaryGrowthRate"
-              {...register('salaryGrowthRate')}
-            />
-          </div>
-          <div>
-            <InputLabel htmlFor="inflationRate">물가 상승률</InputLabel>
-            <FinancialInput
-              type="number"
-              id="inflationRate"
-              {...register('inflationRate')}
-            />
-          </div>
-        </FinancialFormItem>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="investmentGrowthRate">투자 상승률</InputLabel>
-            <FinancialInput
-              type="number"
-              id="investmentGrowthRate"
-              {...register('investmentGrowthRate')}
-            />
-          </div>
-        </FinancialFormItem>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="연봉 상승률"
+            type="number"
+            id="salaryGrowthRate"
+            {...register('salaryGrowthRate')}
+          />
+          <FinancialInputField
+            label="물가 상승률"
+            type="number"
+            id="inflationRate"
+            {...register('inflationRate')}
+          />
+        </FinancialFormRow>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="투자 상승률"
+            type="number"
+            id="investmentGrowthRate"
+            {...register('investmentGrowthRate')}
+          />
+        </FinancialFormRow>
 
         <BottomFixedContainer>
           <FinancialButtonWrapper>

--- a/frontend/src/features/financial/components/CurrentStatusSummary.tsx
+++ b/frontend/src/features/financial/components/CurrentStatusSummary.tsx
@@ -1,15 +1,14 @@
 import BottomFixedContainer from '@/shared/ui/bottom-fixed/BottomFixedContainer';
-import InputLabel from '@/shared/ui/InputLabel';
 import { PageTitle } from '@/shared/ui/PageTitle';
 import ProgressButton from '@/shared/ui/ProgressButton';
 import {
   FinancialButtonWrapper,
   FinancialForm,
-  FinancialFormItem,
-  FinancialInput,
+  FinancialFormRow,
   FinancialSection,
 } from '../ui/Financial';
 import { useForm } from 'react-hook-form';
+import FinancialInputField from '../ui/FinancialInputField';
 
 type FormInput = Record<
   'age' | 'salary' | 'assets' | 'investmentRatio',
@@ -58,40 +57,36 @@ export default function CurrentStatusSummary({
         </header>
 
         <FinancialForm onSubmit={handleSubmit(updateFinancialFormState)}>
-          <FinancialFormItem>
-            <div>
-              <InputLabel htmlFor="age">나이</InputLabel>
-              <FinancialInput type="number" id="age" {...register('age')} />
-            </div>
-            <div>
-              <InputLabel htmlFor="salary">연봉</InputLabel>
-              <FinancialInput
-                type="number"
-                id="salary"
-                {...register('salary')}
-              />
-            </div>
-          </FinancialFormItem>
-          <FinancialFormItem>
-            <div>
-              <InputLabel htmlFor="assets">자산</InputLabel>
-              <FinancialInput
-                type="number"
-                id="assets"
-                {...register('assets')}
-              />
-            </div>
-          </FinancialFormItem>
-          <FinancialFormItem>
-            <div>
-              <InputLabel htmlFor="investmentRatio">투자 비중</InputLabel>
-              <FinancialInput
-                type="number"
-                id="investmentRatio"
-                {...register('investmentRatio')}
-              />
-            </div>
-          </FinancialFormItem>
+          <FinancialFormRow>
+            <FinancialInputField
+              label="나이"
+              type="number"
+              id="age"
+              {...register('age')}
+            />
+            <FinancialInputField
+              label="연봉"
+              type="number"
+              id="salary"
+              {...register('salary')}
+            />
+          </FinancialFormRow>
+          <FinancialFormRow>
+            <FinancialInputField
+              label="자산"
+              type="number"
+              id="assets"
+              {...register('assets')}
+            />
+          </FinancialFormRow>
+          <FinancialFormRow>
+            <FinancialInputField
+              label="투자 비중"
+              type="number"
+              id="investmentRatio"
+              {...register('investmentRatio')}
+            />
+          </FinancialFormRow>
 
           <BottomFixedContainer>
             <FinancialButtonWrapper>

--- a/frontend/src/features/financial/components/FixedExpense.tsx
+++ b/frontend/src/features/financial/components/FixedExpense.tsx
@@ -1,15 +1,14 @@
+import { useForm } from 'react-hook-form';
 import BottomFixedContainer from '@/shared/ui/bottom-fixed/BottomFixedContainer';
-import InputLabel from '@/shared/ui/InputLabel';
 import { PageTitle, PageTitleCaption } from '@/shared/ui/PageTitle';
 import ProgressButton from '@/shared/ui/ProgressButton';
 import {
   FinancialButtonWrapper,
   FinancialForm,
-  FinancialFormItem,
-  FinancialInput,
+  FinancialFormRow,
   FinancialSection,
 } from '../ui/Financial';
-import { useForm } from 'react-hook-form';
+import FinancialInputField from '../ui/FinancialInputField';
 
 type FormInput = Record<
   | 'fixedExpenseRent'
@@ -65,54 +64,42 @@ export default function FixedExpense({
       </header>
 
       <FinancialForm onSubmit={handleSubmit(updateFinancialFormState)}>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="fixedExpenseRent">월세 및 관리비</InputLabel>
-            <FinancialInput
-              type="number"
-              id="fixedExpenseRent"
-              {...register('fixedExpenseRent')}
-            />
-          </div>
-          <div>
-            <InputLabel htmlFor="fixedExpenseCommunication">통신비</InputLabel>
-            <FinancialInput
-              type="number"
-              id="fixedExpenseCommunication"
-              {...register('fixedExpenseCommunication')}
-            />
-          </div>
-        </FinancialFormItem>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="fixedExpenseUtilities">
-              전기 및 가스
-            </InputLabel>
-            <FinancialInput
-              type="number"
-              id="fixedExpenseUtilities"
-              {...register('fixedExpenseUtilities')}
-            />
-          </div>
-          <div>
-            <InputLabel htmlFor="fixedExpenseInsurance">보험</InputLabel>
-            <FinancialInput
-              type="number"
-              id="fixedExpenseInsurance"
-              {...register('fixedExpenseInsurance')}
-            />
-          </div>
-        </FinancialFormItem>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="fixedExpenseOther">기타</InputLabel>
-            <FinancialInput
-              type="number"
-              id="fixedExpenseOther"
-              {...register('fixedExpenseOther')}
-            />
-          </div>
-        </FinancialFormItem>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="월세 및 관리비"
+            type="number"
+            id="fixedExpenseRent"
+            {...register('fixedExpenseRent')}
+          />
+          <FinancialInputField
+            label="통신비"
+            type="number"
+            id="fixedExpenseCommunication"
+            {...register('fixedExpenseCommunication')}
+          />
+        </FinancialFormRow>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="전기 및 가스"
+            type="number"
+            id="fixedExpenseUtilities"
+            {...register('fixedExpenseUtilities')}
+          />
+          <FinancialInputField
+            label="보험"
+            type="number"
+            id="fixedExpenseInsurance"
+            {...register('fixedExpenseInsurance')}
+          />
+        </FinancialFormRow>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="기타"
+            type="number"
+            id="fixedExpenseOther"
+            {...register('fixedExpenseOther')}
+          />
+        </FinancialFormRow>
 
         <BottomFixedContainer>
           <FinancialButtonWrapper>

--- a/frontend/src/features/financial/components/FixedExpense.tsx
+++ b/frontend/src/features/financial/components/FixedExpense.tsx
@@ -9,6 +9,8 @@ import {
   FinancialSection,
 } from '../ui/Financial';
 import FinancialInputField from '../ui/FinancialInputField';
+import { sum } from '@/shared/utils/numberUtils';
+import FinancialTotalField from '../ui/FinancialTotalField';
 
 type FormInput = Record<
   | 'fixedExpenseRent'
@@ -38,7 +40,7 @@ export default function FixedExpense({
   goNext,
   setFunnelContext,
 }: Props) {
-  const { register, handleSubmit, getValues } = useForm({
+  const { register, handleSubmit, watch } = useForm({
     defaultValues: {
       fixedExpenseRent,
       fixedExpenseCommunication,
@@ -47,10 +49,10 @@ export default function FixedExpense({
       fixedExpenseOther,
     },
   });
+  const values = watch();
+  const total = sum(...Object.values(values).map(Number));
 
   const updateFinancialFormState = () => {
-    const values = getValues();
-
     setFunnelContext(values);
     goNext();
   };
@@ -102,6 +104,10 @@ export default function FixedExpense({
         </FinancialFormRow>
 
         <BottomFixedContainer>
+          <FinancialTotalField
+            htmlFor="fixedExpenseRent fixedExpenseCommunication fixedExpenseUtilities fixedExpenseInsurance fixedExpenseOther"
+            total={total}
+          />
           <FinancialButtonWrapper>
             <ProgressButton
               type="submit"

--- a/frontend/src/features/financial/components/VariableExpense.tsx
+++ b/frontend/src/features/financial/components/VariableExpense.tsx
@@ -9,6 +9,8 @@ import {
 } from '../ui/Financial';
 import { useForm } from 'react-hook-form';
 import FinancialInputField from '../ui/FinancialInputField';
+import FinancialTotalField from '../ui/FinancialTotalField';
+import { sum } from '@/shared/utils/numberUtils';
 
 type FormInput = Record<
   | 'variableExpenseFood'
@@ -31,7 +33,7 @@ export default function VariableExpense({
   totalStep,
   setFunnelContext,
 }: Props) {
-  const { register, handleSubmit, getValues } = useForm({
+  const { register, handleSubmit, watch } = useForm({
     defaultValues: {
       variableExpenseFood,
       variableExpenseTransport,
@@ -39,10 +41,10 @@ export default function VariableExpense({
       variableExpenseOther,
     },
   });
+  const values = watch();
+  const total = sum(...Object.values(values).map(Number));
 
   const updateFinancialFormState = () => {
-    const values = getValues();
-
     setFunnelContext(values);
   };
 
@@ -85,6 +87,10 @@ export default function VariableExpense({
         </FinancialFormRow>
 
         <BottomFixedContainer>
+          <FinancialTotalField
+            htmlFor="variableExpenseFood variableExpenseTransport variableExpenseTravel variableExpenseOther"
+            total={total}
+          />
           <FinancialButtonWrapper>
             <ProgressButton type="submit" total={totalStep} step={totalStep}>
               제출

--- a/frontend/src/features/financial/components/VariableExpense.tsx
+++ b/frontend/src/features/financial/components/VariableExpense.tsx
@@ -1,15 +1,14 @@
 import BottomFixedContainer from '@/shared/ui/bottom-fixed/BottomFixedContainer';
-import InputLabel from '@/shared/ui/InputLabel';
 import { PageTitle, PageTitleCaption } from '@/shared/ui/PageTitle';
 import ProgressButton from '@/shared/ui/ProgressButton';
 import {
   FinancialButtonWrapper,
   FinancialForm,
-  FinancialFormItem,
-  FinancialInput,
+  FinancialFormRow,
   FinancialSection,
 } from '../ui/Financial';
 import { useForm } from 'react-hook-form';
+import FinancialInputField from '../ui/FinancialInputField';
 
 type FormInput = Record<
   | 'variableExpenseFood'
@@ -56,42 +55,34 @@ export default function VariableExpense({
       </header>
 
       <FinancialForm onSubmit={handleSubmit(updateFinancialFormState)}>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="variableExpenseFood">식비</InputLabel>
-            <FinancialInput
-              type="number"
-              id="variableExpenseFood"
-              {...register('variableExpenseFood')}
-            />
-          </div>
-          <div>
-            <InputLabel htmlFor="variableExpenseTransport">교통비</InputLabel>
-            <FinancialInput
-              type="number"
-              id="variableExpenseTransport"
-              {...register('variableExpenseTransport')}
-            />
-          </div>
-        </FinancialFormItem>
-        <FinancialFormItem>
-          <div>
-            <InputLabel htmlFor="variableExpenseTravel">여행비</InputLabel>
-            <FinancialInput
-              type="number"
-              id="variableExpenseTravel"
-              {...register('variableExpenseTravel')}
-            />
-          </div>
-          <div>
-            <InputLabel htmlFor="variableExpenseOther">기타</InputLabel>
-            <FinancialInput
-              type="number"
-              id="variableExpenseOther"
-              {...register('variableExpenseOther')}
-            />
-          </div>
-        </FinancialFormItem>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="식비"
+            type="number"
+            id="variableExpenseFood"
+            {...register('variableExpenseFood')}
+          />
+          <FinancialInputField
+            label="교통비"
+            type="number"
+            id="variableExpenseTransport"
+            {...register('variableExpenseTransport')}
+          />
+        </FinancialFormRow>
+        <FinancialFormRow>
+          <FinancialInputField
+            label="여행비"
+            type="number"
+            id="variableExpenseTravel"
+            {...register('variableExpenseTravel')}
+          />
+          <FinancialInputField
+            label="기타"
+            type="number"
+            id="variableExpenseOther"
+            {...register('variableExpenseOther')}
+          />
+        </FinancialFormRow>
 
         <BottomFixedContainer>
           <FinancialButtonWrapper>

--- a/frontend/src/features/financial/ui/Financial.ts
+++ b/frontend/src/features/financial/ui/Financial.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Input from '@/shared/ui/Input';
 
 export const FinancialSection = styled.section`
   margin-top: 20px;
@@ -12,18 +11,11 @@ export const FinancialForm = styled.form`
   margin-top: 40px;
 `;
 
-export const FinancialFormItem = styled.div`
-  display: flex;
+export const FinancialFormRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 16px;
   width: 100%;
-
-  & > div {
-    width: 100%;
-  }
-`;
-
-export const FinancialInput = styled(Input)`
-  text-align: right;
 `;
 
 export const FinancialButtonWrapper = styled.div`

--- a/frontend/src/features/financial/ui/FinancialInputField.tsx
+++ b/frontend/src/features/financial/ui/FinancialInputField.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import InputLabel from '@/shared/ui/InputLabel';
+import Input from '@/shared/ui/Input';
+import {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+} from 'react';
+
+type Props = Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'id'> & {
+  label: LabelHTMLAttributes<HTMLLabelElement>['children'];
+};
+
+const FinancialInputField = forwardRef(function FinancialInputField(
+  { label, id, ...props }: Props,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  return (
+    <div>
+      <InputLabel htmlFor={id}>{label}</InputLabel>
+      <FinancialInput ref={ref} id={id} {...props} />
+    </div>
+  );
+});
+
+const FinancialInput = styled(Input)`
+  text-align: right;
+`;
+
+export default FinancialInputField;

--- a/frontend/src/features/financial/ui/FinancialTotalField.tsx
+++ b/frontend/src/features/financial/ui/FinancialTotalField.tsx
@@ -1,0 +1,42 @@
+import { formatNumberWithComma } from '@/shared/utils/numberUtils';
+import { OutputHTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+type Props = Omit<OutputHTMLAttributes<HTMLOutputElement>, 'children'> & {
+  total: number;
+};
+
+export default function FinancialTotalField({ total, ...props }: Props) {
+  return (
+    <Wrapper>
+      <Container>
+        <Label htmlFor="result">종합</Label>
+        <Output id="result" name="result" {...props}>
+          {formatNumberWithComma(total)}
+        </Output>
+      </Container>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  border-top: 1px solid ${(props) => props.theme.colors.grayLine};
+`;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: ${(props) => props.theme.pageLayout.breakPoint};
+  padding: 16px calc(${(props) => props.theme.pageLayout.paddingX} + 4px) 24px;
+  margin: 0 auto;
+`;
+
+const Label = styled.label`
+  font-weight: 600;
+  color: ${(props) => props.theme.colors.grayDark};
+`;
+
+const Output = styled.output`
+  font-weight: 600;
+`;

--- a/frontend/src/shared/utils/numberUtils.ts
+++ b/frontend/src/shared/utils/numberUtils.ts
@@ -1,0 +1,10 @@
+export const sum = (...values: number[]) => {
+  return [...values].reduce((acc, number) => {
+    acc += number;
+    return acc;
+  }, 0);
+};
+
+export const formatNumberWithComma = (number: number) => {
+  return String(number).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};


### PR DESCRIPTION
## 개요

재무 입력 페이지 내 종합 항목 추가 및 리팩토링

## 변경사항

- 재무 입력 페이지 내 종합 항목 추가 
- 재사용을 위한 div > label + input 구조 컴포넌트화: FinancialInputField
- FinancialFormItem 컴포넌트 이름 변경 및 css 수정: FinancialFormRow

## 테스트

- 로컬에서 직접 확인

## 참고사항

- 관련 이슈 번호: #32 #33 
