### PR TITLE
Fix/37 bottomfixed 관련 에러 해결

### DIFF
--- a/frontend/src/app/layouts/RootLayout.tsx
+++ b/frontend/src/app/layouts/RootLayout.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Outlet, useMatchRoute } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
-import { BottomFixedProvider } from '@/shared/ui/bottom-fixed/BottomFixedContext';
 import Footer from '@/widgets/footer/Footer';
 import styled from 'styled-components';
+import BottomFixedProvider from '@/shared/ui/bottom-fixed/BottomFixedProvider';
 
 export default function RootLayout() {
   const matchRoute = useMatchRoute();

--- a/frontend/src/shared/ui/bottom-fixed/BottomFixedContainer.tsx
+++ b/frontend/src/shared/ui/bottom-fixed/BottomFixedContainer.tsx
@@ -2,6 +2,8 @@ import { PropsWithChildren, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import useBottomFixedContainer from './useBottomFixedContainer';
 
+const PADDING = 40;
+
 export default function BottomFixedContainer({ children }: PropsWithChildren) {
   const { bottomPosition } = useBottomFixedContainer();
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -10,10 +12,11 @@ export default function BottomFixedContainer({ children }: PropsWithChildren) {
   useEffect(() => {
     if (!wrapperRef.current || !containerRef.current) return;
 
+    const containerHeight = containerRef.current.getBoundingClientRect().height;
+
     // Fixed 컴포넌트에 의해 가려지는 부분이 없도록 height 값 추가
-    const PADDING = 40;
-    wrapperRef.current.style.height = `${bottomPosition + PADDING}px`;
-  }, []);
+    wrapperRef.current.style.height = `${bottomPosition + containerHeight + PADDING}px`;
+  }, [bottomPosition]);
 
   return (
     <div ref={wrapperRef}>

--- a/frontend/src/shared/ui/bottom-fixed/BottomFixedContainer.tsx
+++ b/frontend/src/shared/ui/bottom-fixed/BottomFixedContainer.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { useBottomFixedContainer } from './BottomFixedContext';
+import useBottomFixedContainer from './useBottomFixedContainer';
 
 export default function BottomFixedContainer({ children }: PropsWithChildren) {
   const { bottomPosition } = useBottomFixedContainer();

--- a/frontend/src/shared/ui/bottom-fixed/BottomFixedContext.tsx
+++ b/frontend/src/shared/ui/bottom-fixed/BottomFixedContext.tsx
@@ -1,26 +1,4 @@
-import { createContext, ProviderProps, useContext } from 'react';
+import { createContext } from 'react';
+import { ContextValue } from './type';
 
-type ContextValue = {
-  bottomPosition: number;
-};
-
-const Context = createContext<ContextValue | null>(null);
-
-export function BottomFixedProvider({
-  value,
-  children,
-}: ProviderProps<ContextValue>) {
-  return <Context.Provider value={value}>{children}</Context.Provider>;
-}
-
-export function useBottomFixedContainer() {
-  const context = useContext(Context);
-
-  if (!context) {
-    throw new Error(
-      'BottomFixedProvider 하위 컴포넌트에서만 호출할 수 있습니다.',
-    );
-  }
-
-  return context;
-}
+export const Context = createContext<ContextValue | null>(null);


### PR DESCRIPTION
## 개요

BottomFixed와 관련된 에러를 해결했습니다.

## 변경사항

- BottomFixedContext 파일 및 import 문 수정: merge 충돌 해결하면서 변경된 코드가 아닌 변경 전 코드가 사용되고 있었던 문제 해결
- Fixed로 띄워진 영역이 Fixed 되지 않은 레이어를 가리는 문제 해결:  wrapper가 fixed container의 height 값 만큼 여백을 가질 수 있도록 로직 수정

## 테스트

- 로컬에서 직접 확인

## 참고사항

- 관련 이슈 번호: #37 
