### PR TITLE
Feat/31 financial api 연결

### DIFF
--- a/frontend/src/features/financial/api/index.ts
+++ b/frontend/src/features/financial/api/index.ts
@@ -1,0 +1,8 @@
+import { CalculateFinancialRequestBody } from './type';
+import instance from './instance';
+
+export const calculateFinancial = async (
+  body: CalculateFinancialRequestBody,
+) => {
+  return instance.post('/financial/calculate', body);
+};

--- a/frontend/src/features/financial/api/instance.ts
+++ b/frontend/src/features/financial/api/instance.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const instance = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}`,
+  withCredentials: true,
+});
+
+export default instance;

--- a/frontend/src/features/financial/api/queryKey.tsx
+++ b/frontend/src/features/financial/api/queryKey.tsx
@@ -1,0 +1,4 @@
+export const queryKey = {
+  all: ['financial'],
+  calculate: () => [...queryKey.all, 'calculate'],
+} as const;

--- a/frontend/src/features/financial/api/type.ts
+++ b/frontend/src/features/financial/api/type.ts
@@ -1,0 +1,51 @@
+export type Email = string;
+export type Time = string;
+export type Id = number;
+
+export type CalculateFinancialRequestBody = {
+  current_user: {
+    age: number;
+    salary: number;
+    assets: number;
+    investRate: number;
+  };
+  annual_change_rate: {
+    salary: number;
+    inflation: number;
+    investment: number;
+  };
+  monthly_fixed_cost: {
+    rent: number;
+    communication: number;
+    insurance: number;
+    etc: number;
+  };
+  monthly_variable_cost: {
+    food: number;
+    travel: number;
+    transportation: number;
+    etc: number;
+  };
+};
+
+export type CalculateFinancialResponseBody = {
+  assetsPerAge: [
+    {
+      currentState: {
+        age: number;
+        salary: number;
+        monthlySalary: number;
+        afterTaxMonthlySalary: number;
+      };
+      currentAssets: {
+        cash: number;
+        assets: number;
+        total: number;
+      };
+      totalInAndOut: {
+        income: number;
+        cost: number;
+      };
+    },
+  ];
+};

--- a/frontend/src/features/financial/components/AnnualChangeRate.tsx
+++ b/frontend/src/features/financial/components/AnnualChangeRate.tsx
@@ -10,41 +10,29 @@ import {
 import { useForm } from 'react-hook-form';
 import FinancialInputField from '../ui/FinancialInputField';
 
-type FormInput = Record<
-  'salaryGrowthRate' | 'inflationRate' | 'investmentGrowthRate',
-  number
->;
+type FormInput = Record<'salary' | 'inflation' | 'investment', number>;
 
-type Props = FormInput & {
+type Props = {
+  defaultValues: FormInput;
   totalStep: number;
   currentStep: string;
   currentStepIndex: number;
-  goNext: () => void;
-  setFunnelContext: (context: FormInput) => void;
+  onNext: (values: FormInput) => void;
 };
 
-export function ChangeRate({
-  salaryGrowthRate,
-  inflationRate,
-  investmentGrowthRate,
+export default function AnnualChangeRate({
+  defaultValues,
   currentStepIndex,
   totalStep,
-  goNext,
-  setFunnelContext,
+  onNext,
 }: Props) {
   const { register, handleSubmit, getValues } = useForm({
-    defaultValues: {
-      salaryGrowthRate,
-      inflationRate,
-      investmentGrowthRate,
-    },
+    defaultValues,
   });
 
   const updateFinancialFormState = () => {
     const values = getValues();
-
-    setFunnelContext(values);
-    goNext();
+    onNext(values);
   };
 
   return (
@@ -58,22 +46,22 @@ export function ChangeRate({
           <FinancialInputField
             label="연봉 상승률"
             type="number"
-            id="salaryGrowthRate"
-            {...register('salaryGrowthRate')}
+            id="salary"
+            {...register('salary')}
           />
           <FinancialInputField
             label="물가 상승률"
             type="number"
-            id="inflationRate"
-            {...register('inflationRate')}
+            id="inflation"
+            {...register('inflation')}
           />
         </FinancialFormRow>
         <FinancialFormRow>
           <FinancialInputField
             label="투자 상승률"
             type="number"
-            id="investmentGrowthRate"
-            {...register('investmentGrowthRate')}
+            id="investment"
+            {...register('investment')}
           />
         </FinancialFormRow>
 

--- a/frontend/src/features/financial/components/CurrentUser.tsx
+++ b/frontend/src/features/financial/components/CurrentUser.tsx
@@ -10,43 +10,29 @@ import {
 import { useForm } from 'react-hook-form';
 import FinancialInputField from '../ui/FinancialInputField';
 
-type FormInput = Record<
-  'age' | 'salary' | 'assets' | 'investmentRatio',
-  number
->;
+type FormInput = Record<'age' | 'salary' | 'assets' | 'investRate', number>;
 
-type Props = FormInput & {
+type Props = {
+  defaultValues: FormInput;
   totalStep: number;
   currentStep: string;
   currentStepIndex: number;
-  goNext: () => void;
-  setFunnelContext: (context: FormInput) => void;
+  onNext: (values: FormInput) => void;
 };
 
-export default function CurrentStatusSummary({
-  age,
-  salary,
-  assets,
-  investmentRatio,
+export default function CurrentUser({
+  defaultValues,
   currentStepIndex,
   totalStep,
-  goNext,
-  setFunnelContext,
+  onNext,
 }: Props) {
   const { register, handleSubmit, getValues } = useForm({
-    defaultValues: {
-      age,
-      salary,
-      assets,
-      investmentRatio,
-    },
+    defaultValues,
   });
 
   const updateFinancialFormState = () => {
     const values = getValues();
-
-    setFunnelContext(values);
-    goNext();
+    onNext(values);
   };
 
   return (
@@ -83,8 +69,8 @@ export default function CurrentStatusSummary({
             <FinancialInputField
               label="투자 비중"
               type="number"
-              id="investmentRatio"
-              {...register('investmentRatio')}
+              id="investRate"
+              {...register('investRate')}
             />
           </FinancialFormRow>
 

--- a/frontend/src/features/financial/components/MonthlyFixedCost.tsx
+++ b/frontend/src/features/financial/components/MonthlyFixedCost.tsx
@@ -12,49 +12,30 @@ import FinancialInputField from '../ui/FinancialInputField';
 import { sum } from '@/shared/utils/numberUtils';
 import FinancialTotalField from '../ui/FinancialTotalField';
 
-type FormInput = Record<
-  | 'fixedExpenseRent'
-  | 'fixedExpenseCommunication'
-  | 'fixedExpenseUtilities'
-  | 'fixedExpenseInsurance'
-  | 'fixedExpenseOther',
-  number
->;
+type FormInput = Record<'rent' | 'communication' | 'insurance' | 'etc', number>;
 
-type Props = FormInput & {
+type Props = {
+  defaultValues: FormInput;
   totalStep: number;
   currentStep: string;
   currentStepIndex: number;
-  goNext: () => void;
-  setFunnelContext: (context: FormInput) => void;
+  onNext: (values: FormInput) => void;
 };
 
-export default function FixedExpense({
-  fixedExpenseRent,
-  fixedExpenseCommunication,
-  fixedExpenseUtilities,
-  fixedExpenseInsurance,
-  fixedExpenseOther,
+export default function MonthlyFixedCost({
+  defaultValues,
   currentStepIndex,
   totalStep,
-  goNext,
-  setFunnelContext,
+  onNext,
 }: Props) {
   const { register, handleSubmit, watch } = useForm({
-    defaultValues: {
-      fixedExpenseRent,
-      fixedExpenseCommunication,
-      fixedExpenseUtilities,
-      fixedExpenseInsurance,
-      fixedExpenseOther,
-    },
+    defaultValues,
   });
   const values = watch();
   const total = sum(...Object.values(values).map(Number));
 
   const updateFinancialFormState = () => {
-    setFunnelContext(values);
-    goNext();
+    onNext(values);
   };
 
   return (
@@ -71,27 +52,21 @@ export default function FixedExpense({
             label="월세 및 관리비"
             type="number"
             id="fixedExpenseRent"
-            {...register('fixedExpenseRent')}
+            {...register('rent')}
           />
           <FinancialInputField
             label="통신비"
             type="number"
             id="fixedExpenseCommunication"
-            {...register('fixedExpenseCommunication')}
+            {...register('communication')}
           />
         </FinancialFormRow>
         <FinancialFormRow>
           <FinancialInputField
-            label="전기 및 가스"
-            type="number"
-            id="fixedExpenseUtilities"
-            {...register('fixedExpenseUtilities')}
-          />
-          <FinancialInputField
             label="보험"
             type="number"
             id="fixedExpenseInsurance"
-            {...register('fixedExpenseInsurance')}
+            {...register('insurance')}
           />
         </FinancialFormRow>
         <FinancialFormRow>
@@ -99,7 +74,7 @@ export default function FixedExpense({
             label="기타"
             type="number"
             id="fixedExpenseOther"
-            {...register('fixedExpenseOther')}
+            {...register('etc')}
           />
         </FinancialFormRow>
 

--- a/frontend/src/features/financial/components/MonthlyVariableCost.tsx
+++ b/frontend/src/features/financial/components/MonthlyVariableCost.tsx
@@ -12,40 +12,27 @@ import FinancialInputField from '../ui/FinancialInputField';
 import FinancialTotalField from '../ui/FinancialTotalField';
 import { sum } from '@/shared/utils/numberUtils';
 
-type FormInput = Record<
-  | 'variableExpenseFood'
-  | 'variableExpenseTransport'
-  | 'variableExpenseTravel'
-  | 'variableExpenseOther',
-  number
->;
+type FormInput = Record<'food' | 'travel' | 'transportation' | 'etc', number>;
 
-type Props = FormInput & {
+type Props = {
+  defaultValues: FormInput;
   totalStep: number;
-  setFunnelContext: (context: FormInput) => void;
+  onSubmit: (values: FormInput) => void;
 };
 
-export default function VariableExpense({
-  variableExpenseFood,
-  variableExpenseTransport,
-  variableExpenseTravel,
-  variableExpenseOther,
+export default function MonthlyVariableCost({
+  defaultValues,
   totalStep,
-  setFunnelContext,
+  onSubmit,
 }: Props) {
   const { register, handleSubmit, watch } = useForm({
-    defaultValues: {
-      variableExpenseFood,
-      variableExpenseTransport,
-      variableExpenseTravel,
-      variableExpenseOther,
-    },
+    defaultValues,
   });
   const values = watch();
   const total = sum(...Object.values(values).map(Number));
 
   const updateFinancialFormState = () => {
-    setFunnelContext(values);
+    onSubmit(values);
   };
 
   return (
@@ -61,34 +48,34 @@ export default function VariableExpense({
           <FinancialInputField
             label="식비"
             type="number"
-            id="variableExpenseFood"
-            {...register('variableExpenseFood')}
+            id="variableCostFood"
+            {...register('food')}
           />
           <FinancialInputField
             label="교통비"
             type="number"
-            id="variableExpenseTransport"
-            {...register('variableExpenseTransport')}
+            id="variableCostTravel"
+            {...register('travel')}
           />
         </FinancialFormRow>
         <FinancialFormRow>
           <FinancialInputField
             label="여행비"
             type="number"
-            id="variableExpenseTravel"
-            {...register('variableExpenseTravel')}
+            id="variableCostTransportation"
+            {...register('transportation')}
           />
           <FinancialInputField
             label="기타"
             type="number"
-            id="variableExpenseOther"
-            {...register('variableExpenseOther')}
+            id="variableCostEtc"
+            {...register('etc')}
           />
         </FinancialFormRow>
 
         <BottomFixedContainer>
           <FinancialTotalField
-            htmlFor="variableExpenseFood variableExpenseTransport variableExpenseTravel variableExpenseOther"
+            htmlFor="variableCostFood variableCostTravel variableCostTransportation variableCostEtc"
             total={total}
           />
           <FinancialButtonWrapper>

--- a/frontend/src/pages/_auth.financial-input.tsx
+++ b/frontend/src/pages/_auth.financial-input.tsx
@@ -1,10 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import useFunnel from '@/widgets/funnel/useFunnel';
 import PageNavigator from '@/widgets/PageNavigator';
-import CurrentStatusSummary from '../features/financial/components/CurrentStatusSummary';
-import { ChangeRate } from '../features/financial/components/ChangeRate';
-import FixedExpense from '../features/financial/components/FixedExpense';
-import VariableExpense from '../features/financial/components/VariableExpense';
+import CurrentUser from '@/features/financial/components/CurrentUser';
+import AnnualChangeRate from '@/features/financial/components/AnnualChangeRate';
+import MonthlyFixedCost from '@/features/financial/components/MonthlyFixedCost';
+import MonthlyVariableCost from '@/features/financial/components/MonthlyVariableCost';
+import { useMutation } from '@tanstack/react-query';
+import { queryKey } from '@/features/financial/api/queryKey';
+import { calculateFinancial } from '@/features/financial/api';
+import { toast } from 'react-toastify';
 
 export const Route = createFileRoute('/_auth/financial-input')({
   component: RouteComponent,
@@ -28,25 +32,38 @@ function RouteComponent() {
       '지출(비고정비)',
     ] as const,
     context: {
-      age: 0,
-      salary: 0,
-      assets: 0,
-      investmentRatio: 0,
-
-      salaryGrowthRate: 0,
-      inflationRate: 0,
-      investmentGrowthRate: 0,
-
-      fixedExpenseRent: 0,
-      fixedExpenseCommunication: 0,
-      fixedExpenseUtilities: 0,
-      fixedExpenseInsurance: 0,
-      fixedExpenseOther: 0,
-
-      variableExpenseFood: 0,
-      variableExpenseTransport: 0,
-      variableExpenseTravel: 0,
-      variableExpenseOther: 0,
+      currentUser: {
+        age: 0,
+        salary: 0,
+        assets: 0,
+        investRate: 0,
+      },
+      annualChangeRate: {
+        salary: 0,
+        inflation: 0,
+        investment: 0,
+      },
+      monthlyFixedCost: {
+        rent: 0,
+        communication: 0,
+        insurance: 0,
+        etc: 0,
+      },
+      monthlyVariableCost: {
+        food: 0,
+        travel: 0,
+        transportation: 0,
+        etc: 0,
+      },
+    },
+  });
+  const navigate = useNavigate();
+  const { mutate } = useMutation({
+    mutationKey: queryKey.calculate(),
+    mutationFn: calculateFinancial,
+    onSuccess: () => {
+      toast('제출 완료');
+      navigate({ to: '/analysis/income/salary' });
     },
   });
 
@@ -56,52 +73,62 @@ function RouteComponent() {
 
       <Funnel>
         <FunnelStep name="현재 상황 정리">
-          <CurrentStatusSummary
-            age={funnelContext.age}
-            salary={funnelContext.salary}
-            assets={funnelContext.assets}
-            investmentRatio={funnelContext.investmentRatio}
+          <CurrentUser
+            defaultValues={{ ...funnelContext.currentUser }}
             totalStep={totalStep}
             currentStep={currentStep}
             currentStepIndex={currentStepIndex}
-            goNext={goNext}
-            setFunnelContext={setFunnelContext}
+            onNext={(values) => {
+              setFunnelContext({
+                currentUser: values,
+              });
+              goNext();
+            }}
           />
         </FunnelStep>
         <FunnelStep name="변화율">
-          <ChangeRate
-            salaryGrowthRate={funnelContext.salaryGrowthRate}
-            inflationRate={funnelContext.inflationRate}
-            investmentGrowthRate={funnelContext.investmentGrowthRate}
+          <AnnualChangeRate
+            defaultValues={{ ...funnelContext.annualChangeRate }}
             totalStep={totalStep}
             currentStep={currentStep}
             currentStepIndex={currentStepIndex}
-            goNext={goNext}
-            setFunnelContext={setFunnelContext}
+            onNext={(values) => {
+              setFunnelContext({
+                annualChangeRate: values,
+              });
+              goNext();
+            }}
           />
         </FunnelStep>
         <FunnelStep name="지출(고정비)">
-          <FixedExpense
-            fixedExpenseRent={funnelContext.fixedExpenseRent}
-            fixedExpenseCommunication={funnelContext.fixedExpenseCommunication}
-            fixedExpenseUtilities={funnelContext.fixedExpenseUtilities}
-            fixedExpenseInsurance={funnelContext.fixedExpenseInsurance}
-            fixedExpenseOther={funnelContext.fixedExpenseOther}
+          <MonthlyFixedCost
+            defaultValues={{ ...funnelContext.monthlyFixedCost }}
             totalStep={totalStep}
             currentStep={currentStep}
             currentStepIndex={currentStepIndex}
-            goNext={goNext}
-            setFunnelContext={setFunnelContext}
+            onNext={(values) => {
+              setFunnelContext({
+                monthlyFixedCost: values,
+              });
+              goNext();
+            }}
           />
         </FunnelStep>
         <FunnelStep name="지출(비고정비)">
-          <VariableExpense
-            variableExpenseFood={funnelContext.variableExpenseFood}
-            variableExpenseTransport={funnelContext.variableExpenseTransport}
-            variableExpenseTravel={funnelContext.variableExpenseTravel}
-            variableExpenseOther={funnelContext.variableExpenseOther}
+          <MonthlyVariableCost
+            defaultValues={{ ...funnelContext.monthlyVariableCost }}
             totalStep={totalStep}
-            setFunnelContext={setFunnelContext}
+            onSubmit={(values) => {
+              setFunnelContext({
+                monthlyVariableCost: values,
+              });
+              mutate({
+                current_user: funnelContext.currentUser,
+                annual_change_rate: funnelContext.annualChangeRate,
+                monthly_fixed_cost: funnelContext.monthlyFixedCost,
+                monthly_variable_cost: values,
+              });
+            }}
           />
         </FunnelStep>
       </Funnel>


### PR DESCRIPTION
## 개요

재무입력 페이지에서 작성한 값을 DB에 등록하는 api 연결

## 변경사항

- 재무입력 값 등록 요청 api (calculateFinancial) 구현
- api 적용
- _auth.financial-input 코드 및 하위 컴포넌트 구조 수정

## 테스트

- 로컬에서 직접 확인

## 참고사항

- 관련 이슈 번호: #31 
