### PR TITLE
Fix/funnel 중간 단계 접근시 history 문제 해결

### DIFF
--- a/frontend/src/widgets/funnel/useFunnel.tsx
+++ b/frontend/src/widgets/funnel/useFunnel.tsx
@@ -92,9 +92,12 @@ export default function useFunnel<T, C extends Context>({
       toast('잘못된 경로 접근입니다.');
       setCurrentStep(steps[0]);
       setFunnelContext(defaultContext);
-      setIsDirty(false);
+      setIsDirty(true);
       navigate({
         to: location.pathname,
+        search: {
+          [SEARCH_PARAM_KEY]: steps[START_STEP_INDEX],
+        },
         replace: true,
       });
       return;


### PR DESCRIPTION
## 개요

funnel 중간 단계 접근시 history가 쌓이지 않는 문제 해결

## 변경사항

- 잘못된 경로 접근 시 isDirty, navigate search 설정 값 변경

## 테스트

- 로컬에서 직접 확인

## 참고사항

- 관련 이슈 번호: #49 
